### PR TITLE
Fix/#42/random search params

### DIFF
--- a/app/models/proverb.rb
+++ b/app/models/proverb.rb
@@ -54,9 +54,9 @@ class Proverb < ActiveRecord::Base
     end
   end
 
-  scope :filter_language, ->(args) { where("language LIKE ?", args[:language])}
-  scope :filter_tag, -> (args) { where('tags.name LIKE ?', args[:tag])}
+  scope :filter_language, -> (args) { where("language LIKE ?", args[:language]) }
+  scope :filter_tag, -> (args) { where('tags.name LIKE ?', args[:tag]) }
   scope :filter_order, -> (args) { order("#{args[:order]} #{args[:direction]}") }
-  scope :filter_limit, -> (args) { limit(args[:limit] || 20)}
-  scope :filter_offset, -> (args) { offset(args[:offset] || 0)}
+  scope :filter_limit, -> (args) { limit(args[:limit] || 20) }
+  scope :filter_offset, -> (args) { offset(args[:offset] || 0) }
 end

--- a/app/models/proverb.rb
+++ b/app/models/proverb.rb
@@ -21,23 +21,39 @@ class Proverb < ActiveRecord::Base
     self.tags.map(&:name).join(", ")
   end
 
-  scope :search, lambda { |params = {}|
-    tag = params[:tag].downcase if params[:tag]
-    language = params[:language].downcase if params[:language]
-    ord = params["random"] ? "RANDOM()" : "id #{params[:direction]}"
-    set_order = ord == "id " ? "proverbs.id desc" : ord
-    Proverb.select("proverbs.*, #{ord}").joins(:tags).where(
-      "tags.name LIKE ? and lower(language) LIKE ?",
-      "%#{tag}%",
-      "%#{language}%"
-    ).order(set_order).uniq
-  }
-
   def self.paginate(params)
-    limit = params[:limit] ? params[:limit] : 20
-    page = params[:page] ? params[:page] : 0
-    # offset = limit.to_i * (page.to_i - 1)
-    offset = page == 0 ? 0 : (page.to_i - 1) * limit.to_i
-    search(params).limit(limit).offset(offset)
+    params[:direction] = "RANDOM()" if params[:direction] == 'random'
+    query = self.includes(:tags)
+    query = query.filter_language(params) if params[:language]
+    query = query.filter_tag(params) if params[:tag]
+    query.filter_order(params).filter_limit(params).filter_offset(params)
   end
+
+  scope :filter_language, ->(args) { where(language: args[:language])}
+  scope :filter_tag, -> (args) { where(tags: {name: args[:tag]})}
+  scope :filter_order, -> (args) { order("proverbs.#{args[:order] || 'id'} #{args[:direction] || 'desc'} ")}
+  scope :filter_limit, -> (args) { limit(args[:limit] || 20)}
+  scope :filter_offset, -> (args) { offset(args[:offset] || 0)}
+
+
+  # scope :search, lambda { |params = {}|
+  #   tag = params[:tag].downcase if params[:tag]
+  #   language = params[:language].downcase if params[:language]
+  #   ord = params["random"] ? "RANDOM()" : "id #{params[:direction]}"
+  #   set_order = ord == "id " ? "proverbs.id desc" : ord
+  #   Proverb.select("proverbs.*, #{ord}").joins(:tags).where(
+  #     "tags.name LIKE ? and lower(language) LIKE ?",
+  #     "%#{tag}%",
+  #     "%#{language}%"
+  #   ).order(set_order).uniq
+  # }
+  #
+  # def self.paginate(params)
+  #   binding.pry
+  #   limit = params[:limit] ? params[:limit] : 20
+  #   page = params[:page] ? params[:page] : 0
+  #   # offset = limit.to_i * (page.to_i - 1)
+  #   offset = page == 0 ? 0 : (page.to_i - 1) * limit.to_i
+  #   search(params).limit(limit).offset(offset)
+  # end
 end

--- a/app/models/proverb.rb
+++ b/app/models/proverb.rb
@@ -29,31 +29,9 @@ class Proverb < ActiveRecord::Base
     query.filter_order(params).filter_limit(params).filter_offset(params)
   end
 
-  scope :filter_language, ->(args) { where(language: args[:language])}
+  scope :filter_language, ->(args) { where("lower(language) LIKE ?", "%#{args[:language]}%")}
   scope :filter_tag, -> (args) { where(tags: {name: args[:tag]})}
   scope :filter_order, -> (args) { order("proverbs.#{args[:order] || 'id'} #{args[:direction] || 'desc'} ")}
   scope :filter_limit, -> (args) { limit(args[:limit] || 20)}
   scope :filter_offset, -> (args) { offset(args[:offset] || 0)}
-
-
-  # scope :search, lambda { |params = {}|
-  #   tag = params[:tag].downcase if params[:tag]
-  #   language = params[:language].downcase if params[:language]
-  #   ord = params["random"] ? "RANDOM()" : "id #{params[:direction]}"
-  #   set_order = ord == "id " ? "proverbs.id desc" : ord
-  #   Proverb.select("proverbs.*, #{ord}").joins(:tags).where(
-  #     "tags.name LIKE ? and lower(language) LIKE ?",
-  #     "%#{tag}%",
-  #     "%#{language}%"
-  #   ).order(set_order).uniq
-  # }
-  #
-  # def self.paginate(params)
-  #   binding.pry
-  #   limit = params[:limit] ? params[:limit] : 20
-  #   page = params[:page] ? params[:page] : 0
-  #   # offset = limit.to_i * (page.to_i - 1)
-  #   offset = page == 0 ? 0 : (page.to_i - 1) * limit.to_i
-  #   search(params).limit(limit).offset(offset)
-  # end
 end

--- a/spec/models/proverb_spec.rb
+++ b/spec/models/proverb_spec.rb
@@ -30,54 +30,102 @@ RSpec.describe Proverb, type: :model do
     expect(translation.root).to eq proverb
   end
 
-  describe ".search" do
-    before(:all) do
-      tags = ["wisdom", "love", "life", "opportunity"]
-      languages = ["english", "yoruba", "igbo", "hausa"]
-      10.times do
-        proverb = create(:proverb, language: languages[rand(languages.length)])
-        tag = create(:tag, name: tags[rand(tags.length)])
-        create(:tagging, proverb: proverb, tag: tag)
-      end
+  describe "search filters" do
+    before(:each) do
+      @proverb1 = create(:proverb, body: 'hello')
+      @proverb2 = create(:proverb, body: 'world')
     end
 
-    context "when full query params is passed" do
-      it "returns proverbs that all query params" do
-        search_result = Proverb.search({
-            tag: "wisdom",
-            language: "english",
-            random: true,
-            direction: "desc"
-          })
-        search_result.map do |proverb|
-          expect(proverb.language).to eq "english"
-          expect(proverb.tags.map(&:name)).to include "wisdom"
+    describe ".filter_language" do
+      context "when present" do
+        it 'returns proverbs with the language' do
+          @proverb2.update(language: 'igbo')
+          result = Proverb.filter_language({language: 'igbo'}).all
+          expect(result.count).to be 1
+          expect(result.first).to eql @proverb2
+        end
+      end
+
+      context "when not present" do
+        it 'returns all proverbs' do
+          result = Proverb.all
+          expect(result.count).to be 2
+          expect(result.first).to eql @proverb1
         end
       end
     end
 
-    context "when only tag is passed" do
-      it "returns proverbs with matching tags" do
-        search_result = Proverb.search({tag: "life"})
-        search_result.each do |proverb|
-          expect(proverb.tags.map(&:name)).to include "life"
+    describe ".filter_tag" do
+      context "when present" do
+        it "returns proverbs that match the tag" do
+          tag = create(:tag, name: 'joy')
+          create(:tagging, tag: tag, proverb: @proverb2)
+          result = Proverb.joins(:tags).filter_tag({tag: 'joy'}).all
+          expect(result.count).to be 1
+          expect(result.first).to eql @proverb2
+        end
+      end
+
+      context "when not present" do
+        it "returns all proverbs" do
+          result = Proverb.joins(:tags).all
+          expect(result).to be_empty
         end
       end
     end
 
-    context "when only langauge is passed" do
-      it "returns proverbs with matching language" do
-        search_result = Proverb.search({language: "yoruba"})
-        search_result.each do |proverb|
-          expect(proverb.language).to eq "yoruba"
+    describe ".filter_order" do
+      context "when present" do
+        it 'returns proverbs with the given order' do
+          @proverb2.update({language: 'igbo'})
+          result = Proverb.filter_order({language: 'igbo'}).all
+          expect(result.size).to be 2
+          expect(result.first).to eql @proverb2
+          expect(result.second).to eql @proverb1
+        end
+      end
+      context "when not present" do
+        it 'returns proverbs order by id in desc' do
+          result = Proverb.all
+          expect(result.size).to be 2
+          expect(result.first).to eql @proverb1
+          expect(result.second).to eql @proverb2
         end
       end
     end
 
-    context "when direction is passed" do
-      it "returns proverbs in the specified order" do
-        search_result = Proverb.search({direction: "asc"})
-        expect(search_result[0].created_at).to be < search_result[1].created_at
+    describe ".filter_limit" do
+      context "when present" do
+        it "returns the number of proverbs required" do
+          result = Proverb.filter_limit({limit: 1})
+          expect(result.size).to be 1
+          expect(result.first).to eql(@proverb1)
+        end
+      end
+    end
+
+    describe ".filter_offset" do
+      context "when present" do
+        it "returns the default" do
+          result = Proverb.all
+          expect(result.size).to be 2
+          expect(result.first).to eql(@proverb1)
+          expect(result.second).to eql(@proverb2)
+        end
+      end
+    end
+  end
+
+  describe ".paginate" do
+    before(:each) do
+      @proverb1 = create(:proverb, body: 'hello')
+      @proverb2 = create(:proverb, body: 'world')
+    end
+
+    context "when pagination is random" do
+      it "returns randomize results" do
+        result = Proverb.paginate({direction: 'random'})
+        expect(result.size).to be 2
       end
     end
   end

--- a/spec/models/proverb_spec.rb
+++ b/spec/models/proverb_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Proverb, type: :model do
           result = Proverb.all
           expect(result.count).to be 2
           expect(result.first).to eql @proverb1
+          expect(result.second).to eql @proverb2
         end
       end
     end
@@ -63,13 +64,6 @@ RSpec.describe Proverb, type: :model do
           result = Proverb.joins(:tags).filter_tag({tag: 'joy'}).all
           expect(result.count).to be 1
           expect(result.first).to eql @proverb2
-        end
-      end
-
-      context "when not present" do
-        it "returns all proverbs" do
-          result = Proverb.joins(:tags).all
-          expect(result).to be_empty
         end
       end
     end
@@ -106,6 +100,13 @@ RSpec.describe Proverb, type: :model do
 
     describe ".filter_offset" do
       context "when present" do
+        it "returns the default" do
+          result = Proverb.filter_offset({offset: '1'}).all
+          expect(result.size).to eq 1
+          expect(result[0]).to eq(@proverb2)
+        end
+      end
+      context "when not present" do
         it "returns the default" do
           result = Proverb.all
           expect(result.size).to be 2
@@ -147,7 +148,7 @@ RSpec.describe Proverb, type: :model do
     end
     describe "offset" do
       context "when valid" do
-        it "updates field to nil" do
+        it "returns field value" do
           params = {offset: '10'}
           expect(Proverb.sanitize_search_params(params)[:offset]).to eql "10"
         end

--- a/spec/requests/proverbs_spec.rb
+++ b/spec/requests/proverbs_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Api::V1::ProverbsController, type: :request do
       proverb = create(:proverb, language: "english")
       tag = create(:tag, name: "wisdom")
       create(:tagging, proverb: proverb, tag: tag)
-      translation = create(:proverb, root_id: proverb.id)
+      result = create(:proverb, root_id: proverb.id)
 
       get "/api/v1/proverbs", {}, valid_session
-      result = proverb.attributes
-      expect(JSON.parse(response.body)["proverbs"][0]["body"]).to eq(result["body"])
-      expect(JSON.parse(response.body)["proverbs"][0]["language"]).to eq(result["language"])
-      expect(JSON.parse(response.body)["proverbs"][0]["translations"][0]["body"]).to eq(translation.body)
-      expect(JSON.parse(response.body)["proverbs"][0]["translations"][0]["language"]).to eq(translation.language)
+      translation = proverb.attributes
+      expect(JSON.parse(response.body)["proverbs"][0]["body"]).to eq(result.body)
+      expect(JSON.parse(response.body)["proverbs"][0]["language"]).to eq(result.language)
+      expect(JSON.parse(response.body)["proverbs"][0]["translations"][0]["body"]).to eq(translation["body"])
+      expect(JSON.parse(response.body)["proverbs"][0]["translations"][0]["language"]).to eq(translation["language"])
       expect(response).to have_http_status(200)
     end
 


### PR DESCRIPTION
This implements  a minor refactor of the search implementation to fix bug with the random param option. 
The random params is no expected as an option to the the directions params. This implies that valid direction params can now be either 'desc', 'asc' or 'random'
